### PR TITLE
Add referral code to bootcamp application form

### DIFF
--- a/netlify/functions/submit-application.js
+++ b/netlify/functions/submit-application.js
@@ -34,7 +34,7 @@ exports.handler = async (event, context) => {
   // Initialise HubSpot client
   const hubspot = require("@hubspot/api-client");
   const hubspotClient = new hubspot.Client({
-    apiKey: process.env.HUBSPOT_API_KEY,
+    accessToken: process.env.HUBSPOT_PRIVATE_APP_ACCESS_TOKEN,
   });
 
   // Initialise HubSpot contact data
@@ -43,7 +43,7 @@ exports.handler = async (event, context) => {
     properties: {
       ...formData,
       contact_source: "website_apply_form",
-      bootcamp_funnel_status: "bootcamp_apply",
+      funnel_status: "bootcamp_applied",
     },
   };
 

--- a/netlify/functions/submit-application.js
+++ b/netlify/functions/submit-application.js
@@ -43,7 +43,7 @@ exports.handler = async (event, context) => {
     properties: {
       ...formData,
       contact_source: "website_apply_form",
-      funnel_status: "bootcamp_applied",
+      bootcamp_funnel_status: "bootcamp_apply",
     },
   };
 

--- a/src/pages/courses/bootcamp/apply.js
+++ b/src/pages/courses/bootcamp/apply.js
@@ -257,7 +257,7 @@ const ApplicationForm = () => {
               md="6"
               controlId="validationCustom08"
             >
-              <Form.Label>How did you hear about us? </Form.Label>
+              <Form.Label>How did you hear about us?</Form.Label>
               <Form.Select
                 required
                 id="source"
@@ -278,6 +278,21 @@ const ApplicationForm = () => {
               <Form.Control.Feedback type="invalid">
                 Please make a valid choice.
               </Form.Control.Feedback>
+            </Form.Group>
+            <Form.Group
+              as={Col}
+              className="mb-3"
+              md="6"
+            >
+              <Form.Label>Referral code</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="--"
+                name="referral_code"
+                value={inputs.referral_code || ""}
+                onChange={handleChange}
+              />
+              <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
             </Form.Group>
             <Form.Group
               as={Col}

--- a/src/pages/courses/bootcamp/apply.js
+++ b/src/pages/courses/bootcamp/apply.js
@@ -242,7 +242,7 @@ const ApplicationForm = () => {
               md="6"
               controlId="validationCustom07"
             >
-              <Form.Label>LinkedIn profile</Form.Label>
+              <Form.Label>LinkedIn profile (optional)</Form.Label>
               <Form.Control
                 type="text"
                 placeholder="https://linkedin.com/in/example"
@@ -284,7 +284,7 @@ const ApplicationForm = () => {
               className="mb-3"
               md="6"
             >
-              <Form.Label>Referral code</Form.Label>
+              <Form.Label>Referral code (optional)</Form.Label>
               <Form.Control
                 type="text"
                 placeholder="--"

--- a/src/pages/courses/bootcamp/index.md
+++ b/src/pages/courses/bootcamp/index.md
@@ -144,7 +144,7 @@ admissions:
 tuition:
   heading: Tuition
   sidebarlabel: Tuition
-  subheading: We accept bank transfers, PayNow, credit cards, and installment payments via Atome. Additional charges apply to credit cards and Atome payments. Fees are payable upfront before course commencement.
+  subheading: We accept bank transfers, PayNow, credit cards, and instalment payments via Atome. Additional charges apply to credit cards and Atome payments. Fees are payable upfront before course commencement.
   payment: Fees are payable upfront before course commencement.
   card:
     - frequency: /img/homepage/part-time-icon.png

--- a/src/pages/courses/bootcamp/index.md
+++ b/src/pages/courses/bootcamp/index.md
@@ -144,7 +144,7 @@ admissions:
 tuition:
   heading: Tuition
   sidebarlabel: Tuition
-  subheading: We accept bank transfers, paynow, credit cards, and installment payments via Atome. Additional charges apply to credit cards and Atome payments. Fees are payable upfront before course commencement.
+  subheading: We accept bank transfers, PayNow, credit cards, and installment payments via Atome. Additional charges apply to credit cards and Atome payments. Fees are payable upfront before course commencement.
   payment: Fees are payable upfront before course commencement.
   card:
     - frequency: /img/homepage/part-time-icon.png

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 
 const ApplicationSuccessful = () => {
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    if (typeof window.gtag !== "undefined") {
       window.gtag("event", "conversion", {
         send_to: "AW-10817488949/-jLiCLDBr7cDELWQl6Yo",
       });


### PR DESCRIPTION
- Use HubSpot private app access token instead of api key since it will be deprecated in November
- Correct spelling for `instalment`